### PR TITLE
feat: native Apple Silicon and relative reverse-proxy web support

### DIFF
--- a/web/backend/Dockerfile.arm
+++ b/web/backend/Dockerfile.arm
@@ -1,0 +1,27 @@
+# Inherit directly from the native fbpmn CLI image built from the top-level Dockerfile.arm
+FROM fbpmn-cli-java21
+
+WORKDIR /api
+
+# 1. Install python3, pip, and mysql compiler requirements
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    default-libmysqlclient-dev \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ensure wfbpmn-check is executable and available in PATH
+RUN ln -s /opt/fbpmn/scripts/wfbpmn-check /usr/local/bin/wfbpmn-check && \
+    chmod +x /opt/fbpmn/scripts/wfbpmn-check /usr/local/bin/wfbpmn-check
+
+# 2. Copy Flask application codebase and configurations
+COPY requirements.txt config.py .flaskenv ./
+COPY ./app app/
+COPY ./data data/
+
+# 3. Install Python dependencies
+RUN pip3 install --no-cache-dir -r ./requirements.txt
+
+EXPOSE 5000
+CMD ["python3", "-m", "gunicorn", "-b", "0.0.0.0:5000", "app.routes:app", "--timeout", "120", "-w", "1", "--threads", "12"]

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -4,9 +4,10 @@ services:
   api:
     build:
       context: ./backend
+      dockerfile: Dockerfile.arm
     image: fbpmn-api
     ports:
-      - "5000:5000"
+      - "5001:5000"
   client:
     build:
       context: ./frontend

--- a/web/frontend/nginx.default.conf
+++ b/web/frontend/nginx.default.conf
@@ -18,7 +18,7 @@ server {
         add_header Cache-Control "public";
     }
 
-    location /api {
+    location ~ ^/(api|version) {
         proxy_pass http://api:5000;
     }
 }

--- a/web/frontend/public/index.html
+++ b/web/frontend/public/index.html
@@ -5,15 +5,7 @@
   <meta charset="utf-8" />
   <title id="title">fBPMN</title>
 
-  <!-- required modeler styles -->
-  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@8.6.1/dist/assets/diagram-js.css">
-  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@8.6.1/dist/assets/bpmn-font/css/bpmn.css">
-
-  <!-- modeler distro -->
-  <script src="https://unpkg.com/bpmn-js@8.6.1/dist/bpmn-modeler.development.js"></script>
-
-  <!-- needed for this example only -->
-  <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>
+  <!-- local assets will be bundled by webpack -->
 
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/web/frontend/src/components/About.js
+++ b/web/frontend/src/components/About.js
@@ -9,7 +9,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 let version;
 
 function setVersion() {
-  fetch("http://localhost:5000/version")
+  fetch("/version")
     .then((res) => res.json())
     .then((data) => {
       version = data.major + "." + data.minor + "." + data.patch;

--- a/web/frontend/src/components/CounterExample/CounterExample.js
+++ b/web/frontend/src/components/CounterExample/CounterExample.js
@@ -6,7 +6,7 @@ import $ from "jquery";
 
 import "./CounterExample.css";
 
-const urlCounterExample = "http://localhost:5000/api/counter_examples/";
+const urlCounterExample = "/api/counter_examples/";
 
 function code_comm_to_name(comm) {
   switch (comm) {
@@ -69,14 +69,14 @@ class CounterExample extends Component {
           lcex: data.lcex,
         });
         this.parseJSON(this.state.lcex);
-        fetch(`http://localhost:5000${data.result}`)
+        fetch(`${data.result}`)
           .then((res) => res.json())
           .then((context) => {
             this.setState({
               comm: code_comm_to_name(context.communication),
               prop: context.property,
             });
-            fetch(`http://localhost:5000${data.result}/verification`)
+            fetch(`${data.result}/verification`)
               .then((res) => res.json())
               .then((verif) => {
                 this.setState({

--- a/web/frontend/src/components/Modeler.js
+++ b/web/frontend/src/components/Modeler.js
@@ -10,7 +10,7 @@ import About from "./About.js";
 import Verifications from "./Verifications.js";
 import VerificationOptions from "./VerificationOptions.js";
 
-const urlVerification = "http://localhost:5000/api/verifications";
+const urlVerification = "/api/verifications";
 
 export const sleep = async (waitTime) =>
   new Promise((resolve) => setTimeout(resolve, waitTime));

--- a/web/frontend/src/components/Results.js
+++ b/web/frontend/src/components/Results.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { FaArrowRight } from "react-icons/fa";
 
 const localhost = "http://localhost:3000";
-const urlVerification = "http://localhost:5000/api/verifications/";
+const urlVerification = "/api/verifications/";
 const columns = [
   { field: "comm", headerName: "Network", width: 110 },
   { field: "prop", headerName: "Property", width: 145 },

--- a/web/frontend/src/components/VerificationDetail.js
+++ b/web/frontend/src/components/VerificationDetail.js
@@ -4,7 +4,7 @@ import "bpmn-js/dist/assets/diagram-js.css";
 import "bpmn-js/dist/assets/bpmn-font/css/bpmn.css";
 import Results from "./Results";
 
-const urlVerification = "http://localhost:5000/api/verifications/";
+const urlVerification = "/api/verifications/";
 
 class VerificationDetail extends Component {
   constructor(props) {

--- a/web/frontend/src/components/Verifications.js
+++ b/web/frontend/src/components/Verifications.js
@@ -8,7 +8,7 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import { BsTrash } from "react-icons/bs";
 
-const urlVerification = "http://localhost:5000/api/verifications";
+const urlVerification = "/api/verifications";
 
 function createData(id, status, value, date) {
   return { id, status, value, date };


### PR DESCRIPTION
This PR introduces native Apple Silicon support for the fBPMN web server backend by inheriting from the precompiled native base image. It also removes hardcoded localhost:5000 API references from the React client, establishing a clean reverse-proxy architecture under Nginx to resolve port conflicts on macOS.